### PR TITLE
Portals Plugin Message Passing w/ Android

### DIFF
--- a/android/IonicPortals/build.gradle
+++ b/android/IonicPortals/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     // Portals Dependency
     implementation 'io.ionic:portals:3.0.1'
 
+    implementation(kotlin("reflect"))
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.3.0'

--- a/android/IonicPortals/src/main/java/io/ionic/portalslibrary/PortalFragment.kt
+++ b/android/IonicPortals/src/main/java/io/ionic/portalslibrary/PortalFragment.kt
@@ -19,6 +19,8 @@ open class PortalFragment : Fragment {
     private val initialPlugins: MutableList<Class<out Plugin?>> = ArrayList()
     private var config: CapConfig? = null
     private val webViewListeners: MutableList<WebViewListener> = ArrayList()
+    private var portalsPlugin: PortalsPlugin? = null
+    private val messageHandlers: MutableMap<String, PortalListener> = HashMap()
 
     constructor() : super(R.layout.fragment_bridge)
 
@@ -119,8 +121,75 @@ open class PortalFragment : Fragment {
                         "window.portalInitialContext = $portalInitialContext", null
                     )
                 }
+
+                override fun onPageLoaded(webView: WebView?) {
+                    super.onPageLoaded(webView)
+                    setupPortalsPlugin()
+                }
             }
+
             webViewListeners.add(listener)
+        }
+    }
+
+    private fun setupPortalsPlugin() {
+        val pluginHandle = getBridge()?.getPlugin("Portals")
+        if (pluginHandle?.instance is PortalsPlugin) {
+            portalsPlugin = pluginHandle.instance as? PortalsPlugin
+            portalsPlugin!!.portalFragment = this
+        }
+    }
+
+    internal fun receiveMessage(message: String, payload: String?) {
+        val msgHandler = messageHandlers[message]
+        msgHandler.let { msgHandler?.onMessageReceived(payload) } ?: run { Logger.error("Portals message handler not registered for '$message'") }
+    }
+
+    /**
+     * Send a message to the web app listening through the Portal.
+     */
+    fun sendMessage(message : String, payload : String) {
+        val data = JSObject()
+        data.put("message", message)
+        data.put("payload", payload)
+        portalsPlugin?.sendMessageToWebApp(data)
+    }
+
+    /**
+     * Register a message receiver to subscribe to messages through the Portal from the web app.
+     *
+     * The name of the message receiver should match the message name used to send messages from
+     * the web app via the Portal. When a message is received the payload will be passed through.
+     */
+    fun addMessageReceiver(name: String, messageHandler: PortalListener) {
+        messageHandlers[name] = messageHandler
+    }
+
+    /**
+     * Link a class with methods decorated with the [PortalMethod] annotation to use as Portals
+     * message receivers.
+     *
+     * The name of the method should match the message name used to send messages via the Portal.
+     * Alternatively the [PortalMethod] annotation name property can be used to designate a
+     * different name. The registered methods should accept a single String representing the payload
+     * of a message sent through the Portal.
+     */
+    fun linkMessageReceivers(messageReceiverParent: Any) {
+        val members = messageReceiverParent.javaClass.kotlin.members.filter { it.annotations.any { annotation -> annotation is PortalMethod } }
+
+        for (member in members) {
+            var methodName = member.name
+            for (annotation in member.annotations) {
+                if (annotation is PortalMethod && annotation.name.isNotEmpty()) {
+                    methodName = annotation.name
+                }
+            }
+
+            messageHandlers[methodName] = object : PortalListener {
+                override fun onMessageReceived(data: String?) {
+                    member.call(messageReceiverParent, data)
+                }
+            }
         }
     }
 }

--- a/android/IonicPortals/src/main/java/io/ionic/portalslibrary/PortalListener.kt
+++ b/android/IonicPortals/src/main/java/io/ionic/portalslibrary/PortalListener.kt
@@ -1,0 +1,5 @@
+package io.ionic.portalslibrary
+
+interface PortalListener {
+    fun onMessageReceived(data: String?)
+}

--- a/android/IonicPortals/src/main/java/io/ionic/portalslibrary/PortalMethod.kt
+++ b/android/IonicPortals/src/main/java/io/ionic/portalslibrary/PortalMethod.kt
@@ -1,0 +1,4 @@
+package io.ionic.portalslibrary
+
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PortalMethod(val name: String = "")

--- a/android/IonicPortals/src/main/java/io/ionic/portalslibrary/PortalsPlugin.kt
+++ b/android/IonicPortals/src/main/java/io/ionic/portalslibrary/PortalsPlugin.kt
@@ -8,11 +8,33 @@ import com.getcapacitor.annotation.CapacitorPlugin
 
 @CapacitorPlugin(name = "Portals")
 class PortalsPlugin : Plugin() {
+
+    var portalFragment : PortalFragment? = null
+    var messageCall: PluginCall? = null
+
     @PluginMethod
     fun echo(call: PluginCall) {
         val value = call.getString("value")
         val ret = JSObject()
         ret.put("value", value)
         call.resolve(ret)
+    }
+
+    @PluginMethod
+    fun sendMessage(call: PluginCall) {
+        call.data.getString("message")?.let { portalFragment?.receiveMessage(it, call.data.getString("payload")) }
+        call.resolve()
+    }
+
+    @PluginMethod(returnType = PluginMethod.RETURN_CALLBACK)
+    fun listenForMessages(pluginCall: PluginCall) {
+        messageCall = pluginCall
+        messageCall?.setKeepAlive(true)
+    }
+
+    internal fun sendMessageToWebApp(data: JSObject) {
+        messageCall?.resolve(data) ?: run {
+            Logger.error("No portals messageCall is saved")
+        }
     }
 }

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -15,6 +15,9 @@ npx cap sync
 
 * [`echo(...)`](#echo)
 * [`getInitialContext()`](#getinitialcontext)
+* [`clearListener(...)`](#clearlistener)
+* [`listenForMessages(...)`](#listenformessages)
+* [`sendMessage(...)`](#sendmessage)
 * [Interfaces](#interfaces)
 
 </docgen-index>
@@ -48,6 +51,51 @@ getInitialContext<T = unknown>() => any
 --------------------
 
 
+### clearListener(...)
+
+```typescript
+clearListener(listener: ClearMessageListener) => any
+```
+
+| Param          | Type                                                                  |
+| -------------- | --------------------------------------------------------------------- |
+| **`listener`** | <code><a href="#clearmessagelistener">ClearMessageListener</a></code> |
+
+**Returns:** <code>any</code>
+
+--------------------
+
+
+### listenForMessages(...)
+
+```typescript
+listenForMessages(callback: PortalCallback) => any
+```
+
+| Param          | Type                                                                                             |
+| -------------- | ------------------------------------------------------------------------------------------------ |
+| **`callback`** | <code>(message: <a href="#portalmessage">PortalMessage</a> \| null, err?: any) =&gt; void</code> |
+
+**Returns:** <code>any</code>
+
+--------------------
+
+
+### sendMessage(...)
+
+```typescript
+sendMessage(message: PortalMessage) => any
+```
+
+| Param         | Type                                                    |
+| ------------- | ------------------------------------------------------- |
+| **`message`** | <code><a href="#portalmessage">PortalMessage</a></code> |
+
+**Returns:** <code>any</code>
+
+--------------------
+
+
 ### Interfaces
 
 
@@ -57,5 +105,20 @@ getInitialContext<T = unknown>() => any
 | ----------- | ------------------- |
 | **`name`**  | <code>string</code> |
 | **`value`** | <code>T</code>      |
+
+
+#### ClearMessageListener
+
+| Prop     | Type                |
+| -------- | ------------------- |
+| **`id`** | <code>string</code> |
+
+
+#### PortalMessage
+
+| Prop          | Type                |
+| ------------- | ------------------- |
+| **`message`** | <code>string</code> |
+| **`payload`** | <code>any</code>    |
 
 </docgen-api>

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1941,7 +1941,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -2516,9 +2515,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.53.1.tgz",
       "integrity": "sha512-yiTCvcYXZEulNWNlEONOQVlhXA/hgxjelFSjNcrwAAIfYx/xqjSHwqg/cCaWOyFRKr+IQBaXwt723m8tCaIUiw==",
       "dev": true,
-      "dependencies": {
-        "fsevents": "~2.3.2"
-      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/plugin/src/android.ts
+++ b/plugin/src/android.ts
@@ -1,8 +1,24 @@
-import type { InitialContext, PortalsPlugin } from './definitions';
+import {
+  ClearMessageListener,
+  InitialContext,
+  PortalCallback,
+  PortalMessage,
+  PortalsPlugin,
+} from './definitions';
 import { getInitialContext } from './shared';
+import { Plugins } from '@capacitor/core';
 
 export class PortalsAndroid implements PortalsPlugin {
-  async echo(options: { value: string; }): Promise<{ value: string; }> {
+  clearListener(listener: ClearMessageListener): Promise<void> {
+    return Plugins.PortalsPlugin.clearListener(listener);
+  }
+  listenForMessages(callback: PortalCallback): Promise<string> {
+    return Plugins.PortalsPlugin.listenForMessages(callback);
+  }
+  sendMessage(message: PortalMessage): Promise<void> {
+    return Plugins.PortalsPlugin.sendMessage(message);
+  }
+  async echo(options: { value: string }): Promise<{ value: string }> {
     console.log('ECHO', options);
     return options;
   }

--- a/plugin/src/definitions.ts
+++ b/plugin/src/definitions.ts
@@ -1,9 +1,25 @@
 export interface PortalsPlugin {
-  echo(options: { value: string; }): Promise<{ value: string; }>;
+  echo(options: { value: string }): Promise<{ value: string }>;
   getInitialContext<T = unknown>(): Promise<InitialContext<T>>;
+  clearListener(listener: ClearMessageListener): Promise<void>;
+  listenForMessages(callback: PortalCallback): Promise<CallbackID>;
+  sendMessage(message: PortalMessage): Promise<void>;
 }
 
 export interface InitialContext<T = unknown> {
   name: string;
   value: T;
+}
+
+export type CallbackID = string;
+
+export type PortalCallback = (message: PortalMessage | null, err?: any) => void;
+
+export interface PortalMessage {
+  message: string;
+  payload?: any;
+}
+
+export interface ClearMessageListener {
+  id: CallbackID;
 }

--- a/plugin/src/web.ts
+++ b/plugin/src/web.ts
@@ -1,10 +1,22 @@
 import { WebPlugin } from '@capacitor/core';
 
-import type { InitialContext, PortalsPlugin } from './definitions';
+import {
+  ClearMessageListener,
+  InitialContext,
+  PortalCallback,
+  PortalMessage,
+  PortalsPlugin,
+} from './definitions';
 import { getInitialContext } from './shared';
 
 export class PortalsWeb extends WebPlugin implements PortalsPlugin {
-  async echo(options: { value: string; }): Promise<{ value: string; }> {
+  async clearListener(_listener: ClearMessageListener) {}
+  async sendMessage(_message: PortalMessage) {}
+  async listenForMessages(_callback: PortalCallback) {
+    return '';
+  }
+
+  async echo(options: { value: string }): Promise<{ value: string }> {
     console.log('ECHO', options);
     return options;
   }
@@ -12,5 +24,4 @@ export class PortalsWeb extends WebPlugin implements PortalsPlugin {
   async getInitialContext<T>(): Promise<InitialContext<T>> {
     return getInitialContext<T>();
   }
-
 }


### PR DESCRIPTION
This PR adds message passing functionality to the Portals Plugin similar to the way it was done in our expenses demo app. A plugin is registered within the Android Portals Native Library code that communicates with a registered message handler or linked class to send and receive messages over the bridge without the need of a third party plugin. Example usage:

**Sending messages from web to native**

A message handler can be registered natively two ways.

1. Directly register a message handler:

```java
portalFragment.addMessageReceiver("dismiss", this::checkout);
```

```java
public void checkout(String result) {
    if(result != null && (result.equals("cancel") || result.equals("success"))) {
        this.dismiss();
    }
}
```

2. Link a class that has public methods decorated using the new `@PortalMethod` annotation.

```java
portalFragment.linkMessageReceivers(this);
```

```java
@PortalMethod
public void dismiss(String payload) {
    if(payload != null && (payload.equals("cancel") || payload.equals("success"))) {
        this.dismiss();
    }
}
```

Once registering a message handler, send a message from the web app code

```ts
Portals.sendMessage({ message: 'dismiss', payload: 'cancel' })
Portals.sendMessage({ message: 'dismiss' })
Portals.sendMessage({ message: 'alert', payload: { title: 'Warning', body: 'This is a native alert' }})
```

**Sending messages from native to web**

Register a listener when the web app loads

```ts
useIonViewDidEnter(async () => {
    try {
      Portals.listenForMessages((msgObj, error) => {
        console.log(msgObj)
      })
    } catch (e) {}
});
```

Send the message from native code

```java
portalFragment.sendMessage("testmsg", "thepayload");
portalFragment.sendMessage("cartContents", myCartObject.toJson());
```