### PR TITLE
docs: Fix getInitialContext docs

### DIFF
--- a/website/docs/reference/android/portal-builder.md
+++ b/website/docs/reference/android/portal-builder.md
@@ -299,9 +299,9 @@ interface MyPortalInitialContext {
 }
 
 Portals.getInitialContext<MyPortalInitialContext>().then(context => {
-    console.log(context.foo)    // "bar"
-    console.log(context.ionic)  // "portals"
-    console.log(context.num)    // 42
+    console.log(context.value.foo)    // "bar"
+    console.log(context.value.ionic)  // "portals"
+    console.log(context.value.num)    // 42
 })
 ```
 

--- a/website/docs/reference/android/portal.md
+++ b/website/docs/reference/android/portal.md
@@ -281,9 +281,9 @@ interface MyPortalInitialContext {
 }
 
 Portals.getInitialContext<MyPortalInitialContext>().then(context => {
-    console.log(context.foo)    // "bar"
-    console.log(context.ionic)  // "portals"
-    console.log(context.num)    // 42
+    console.log(context.value.foo)    // "bar"
+    console.log(context.value.ionic)  // "portals"
+    console.log(context.value.num)    // 42
 })
 ```
 

--- a/website/docs/reference/web/portals-plugin.md
+++ b/website/docs/reference/web/portals-plugin.md
@@ -137,9 +137,8 @@ Gets the [IntialContext](./portals-plugin#initialcontext) of the Portal that was
 
 ```typescript
 // Passed in value is { foo: 'bar' }
-Portals.getInitialContext<{ foo: string; }>(context => {
-    console.log(context.name);  // foo
-    console.log(context.value); // bar
+Portals.getInitialContext<{ foo: string; }>().then(context => {
+    console.log(context.value.foo); // bar
 });
 ```
 
@@ -150,7 +149,7 @@ A real world example might be navigating to a route in a single page application
 Portals.getInitialContext<{ startingRoute: string; }>().then(context => {
   ReactDOM.render(
     <React.StrictMode>
-      <App context={context.value}/> 
+      <App context={context.value}/> {/* context.value = { startingRoute: '/help' } */}
     </React.StrictMode>,
     document.getElementById('root')
   );


### PR DESCRIPTION
- Fix missing `.then()`
- Fix missing `.value` on some `.getInitialContext()` functions