### PR TITLE
Docs - Put portals version number in central place

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -16,5 +16,6 @@
       "tagVersionPrefix": ""
     }
   },
-  "version": "0.2.0"
+  "version": "0.2.0",
+  "capacitorVersion": "3.2.3"
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prelerna:version:latest": "(cd ./scripts && sh ./android-dependency-update.sh)",
     "release:latest": "npm run lerna:version:latest",
     "build": "lerna run build",
-    "postinstall": "lerna bootstrap"
+    "postinstall": "lerna bootstrap",
+    "updateCapVersion": "node scripts/get-latest-capacitor-version.mjs"
   }
 }

--- a/scripts/get-latest-capacitor-version.mjs
+++ b/scripts/get-latest-capacitor-version.mjs
@@ -1,0 +1,28 @@
+import https from 'https'
+import fs from 'fs'
+
+const options = {
+  hostname: 'registry.npmjs.org',
+  path: '/@capacitor/core/',
+  method: 'GET'
+}
+
+const req = https.request(options, res => {
+  let json = ''
+  res.on('data', d => {
+    json += d
+  })
+
+  res.on('close', () => {
+    const latestVersion = JSON.parse(json)['dist-tags'].latest;
+    const lernaConfig = JSON.parse(fs.readFileSync('./lerna.json', 'utf-8'))
+    lernaConfig.capacitorVersion = latestVersion
+    fs.writeFileSync('./lerna.json', JSON.stringify(lernaConfig, null, 2) + '\n')
+  })
+})
+
+req.on('error', error => {
+  console.error(error)
+})
+
+req.end()

--- a/website/docs/getting-started/guide.md
+++ b/website/docs/getting-started/guide.md
@@ -5,6 +5,8 @@ sidebar_label: Getting Started Guide
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
+import { getCapacitorVersion, getPortalsVersion } from '@site/src/util';
 
 ## Signup
 
@@ -23,18 +25,36 @@ values={[
 
 To add Portals to your iOS project, put the following line to your `Podfile`:
 
-```ruby title=Podfile
-pod 'IonicPortals', '~> 0.2.0'
-```
+<CodeBlock className="language-ruby" title="Podfile">
+{`pod 'IonicPortals', '~> ${getPortalsVersion()}'`}
+</CodeBlock>
 
 And then run `pod install`.
 
 </TabItem>
 <TabItem value="android">
 
-To add Portals to your Android project, add the dependency to your top-level `build.gradle` file:
+To add Portals to your Android project, add the dependency to your `build.gradle` files
 
-```groovy title=build.gradle {16}
+<CodeBlock className="language-groovy" title="build.gradle">
+{
+`
+// ----------------------------------------------
+//  Module-level build.gradle
+// ----------------------------------------------
+dependencies {
+    implementation 'io.ionic:portals:${getPortalsVersion()}'
+}`.trim()
+}
+</CodeBlock>
+
+
+And in the top level `build.gradle` file, be sure that you include `jcenter` and `maven` in your repositories section
+
+```groovy title=build.gradle
+// ----------------------------------------------
+//  Top-level build.gradle
+// ----------------------------------------------
 allprojects {
     repositories {
         google()
@@ -45,13 +65,6 @@ allprojects {
         mavenCentral()
     }
 }
-
-// ----------------------------------------------
-//  Module-level build.gradle
-// ----------------------------------------------
-dependencies {
-    implementation 'io.ionic:portals:0.2.0'
-}
 ```
 
 </TabItem>
@@ -60,9 +73,12 @@ dependencies {
 
 To add Portals to your web project(s), install it via NPM:
 
-```bash
-npm install @ionic/portals@0.2.0
-```
+<CodeBlock className="language-bash">
+{`
+npm install @ionic/portals@${getPortalsVersion()}
+`.trim()
+}
+</CodeBlock>
 
 </TabItem>
 

--- a/website/docs/how-to/define-api-in-typescript.md
+++ b/website/docs/how-to/define-api-in-typescript.md
@@ -5,6 +5,8 @@ sidebar_label: Define your own Portal APIs
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
+import { getCapacitorVersion, getPortalsVersion } from '@site/src/util';
 
 One of the biggest benefits of including Ionic Portals in an application is the ability to easily communicate between web and native code using the [PortalsPlugin](../reference/web/portals-plugin). However, in some more niche cases, creating your own Plugins may be neccessary. By creating a [Capacitor Plugin](https://capacitorjs.com/docs/plugins/creating-plugins), you can create your own API to communicate between web and native code.
 
@@ -31,15 +33,14 @@ If you are not using TypeScript, this step is not needed, but you'll need to tak
 
 First, you'll need to [install the proper dependencies](../getting-started/guide#install). On Android, you will need to explicitly add Capacitor to your list of dependencies in order to use the Capacitor Plugin class. On iOS this is not neccessary.
 
-```groovy
-// ----------------------------------------------
-//  Module-level build.gradle
-// ----------------------------------------------
+<CodeBlock className="language-groovy" title="build.gradle">
+{`
 dependencies {
-    implementation 'io.ionic:portals:0.2.0'
-    api 'com.capacitorjs:core:3.2.2'
-}
-```
+    implementation 'io.ionic:portals:${getPortalsVersion()}'
+    api 'com.capacitorjs:core:${getCapacitorVersion()}'
+}.trim()
+`}
+</CodeBlock>
 
 After installing the dependencies once the API has been defined, you can start building the plugin. In this example, the `EchoPlugin`, will extend the base Capacitor `Plugin` class and implement the API that was defined in the previous step.
 

--- a/website/docs/how-to/using-a-capacitor-plugin.md
+++ b/website/docs/how-to/using-a-capacitor-plugin.md
@@ -5,6 +5,8 @@ sidebar_label: Use a Capacitor Plugin
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
+import { getPortalsVersion } from '@site/src/util';
 
 Ionic Portals uses Capacitor under the hood, meaning that you can use [existing Capacitor Core Plugins](https://capacitorjs.com/docs/apis) in your Portals. These plugins allow Portals to use native functionality without much setup on either the native or web developers part.
 
@@ -20,10 +22,13 @@ Ionic Portals uses Capacitor under the hood, meaning that you can use [existing 
 ## Native Usage
 In order to use a Capacitor Plugin, you need to install the plugin as a dependency in your `Podfile`.
 
-```ruby title=Podfile {2}
-pod 'IonicPortals', '~> 0.2.0'
+<CodeBlock className="language-ruby" title="Podfile">
+{
+`pod 'IonicPortals', '~> ${getPortalsVersion()}'
 pod 'CapacitorStorage', '~> 1.2.0'
-```
+`.trim()
+}
+</CodeBlock>
 
 :::caution
 Make sure that the versions in your `Podfile` and `package.json` match! Otherwise you could run into errors.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,4 +1,7 @@
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
+
+const lernaConfig = require('../lerna.json');
+
 module.exports = {
   title: "Ionic Portals",
   tagline: "Portals tagline",
@@ -64,4 +67,8 @@ module.exports = {
       },
     ],
   ],
+  customFields: {
+    portalsVersion: lernaConfig.version,
+    capacitorVersion: lernaConfig.capacitorVersion,
+  }
 };

--- a/website/src/util/index.ts
+++ b/website/src/util/index.ts
@@ -1,0 +1,12 @@
+//@ts-ignore
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+export const getCapacitorVersion = () => {
+    const { siteConfig } = useDocusaurusContext();
+    return siteConfig.customFields.capacitorVersion;
+}
+
+export const getPortalsVersion = () => {
+    const { siteConfig } = useDocusaurusContext();
+    return siteConfig.customFields.portalsVersion;
+}


### PR DESCRIPTION
- Add `updateCapVersion` npm script in root to add latest Capacitor version to `lerna.json`
- Read from `lerna.json` and set `capacitorVersion` and `portalsVersion` as customFields
- Add two helper functions for accessing versions in content
- Converted hardcoded `0.2.0` and `3.2.2` to use new variables