### PR TITLE
android(fix): default config in assets to avoid error

### DIFF
--- a/android/IonicPortals/src/main/assets/capacitor.config.json
+++ b/android/IonicPortals/src/main/assets/capacitor.config.json
@@ -1,4 +1,4 @@
 {
-  "appId": "io.ionic.portals.stub",
+  "appId": "io.ionic.portals.default",
   "appName": "Portals App"
 }

--- a/android/IonicPortals/src/main/assets/capacitor.config.json
+++ b/android/IonicPortals/src/main/assets/capacitor.config.json
@@ -1,0 +1,4 @@
+{
+  "appId": "io.ionic.portals.stub",
+  "appName": "Portals App"
+}


### PR DESCRIPTION
Putting a default config file in the android library suppresses the Capacitor config error in logcat. Capacitor config json files added to application projects will override the default one that's in the library.