### PR TITLE
fix(android): replaced fragment tried to re-instantiate with null portal

### DIFF
--- a/android/IonicPortals/build.gradle.kts
+++ b/android/IonicPortals/build.gradle.kts
@@ -6,13 +6,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion(30)
+    compileSdk = 30
 
     defaultConfig {
-        minSdkVersion(21)
-        targetSdkVersion(30)
-        versionCode = 1
-        versionName = "1.0"
+        minSdk = 21
+        targetSdk = 30
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android/IonicPortals/src/main/kotlin/io/ionic/portals/PortalView.kt
+++ b/android/IonicPortals/src/main/kotlin/io/ionic/portals/PortalView.kt
@@ -86,6 +86,8 @@ class PortalView : FrameLayout {
                 var fmTransaction : FragmentTransaction = fm.beginTransaction()
                 if (existingFragment != null) {
                     fmTransaction.remove(existingFragment)
+                    fmTransaction.commitNowAllowingStateLoss()
+                    fmTransaction = fm.beginTransaction()
                 }
 
                 portalFragment = fm.fragmentFactory.instantiate(


### PR DESCRIPTION
This change removes the old portal before a new replacement portal is added when the activity is killed.

Resolves #94 