### PR TITLE
fix(android): replaced old bridgefragment layout with new portal layout

### DIFF
--- a/android/IonicPortals/src/main/kotlin/io/ionic/portals/PortalFragment.kt
+++ b/android/IonicPortals/src/main/kotlin/io/ionic/portals/PortalFragment.kt
@@ -35,7 +35,7 @@ open class PortalFragment : Fragment {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val layout = if(PortalManager.isRegistered()) R.layout.fragment_bridge else R.layout.fragment_unregistered
+        val layout = if(PortalManager.isRegistered()) R.layout.fragment_portal else R.layout.fragment_unregistered
         return inflater.inflate(layout, container, false)
     }
 

--- a/android/IonicPortals/src/main/res/layout/fragment_portal.xml
+++ b/android/IonicPortals/src/main/res/layout/fragment_portal.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.getcapacitor.CapacitorWebView
+        android:id="@+id/webview"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent" />
+
+</FrameLayout>


### PR DESCRIPTION
Fixes #90 - red background in bridgefragment layout in Capacitor was showing up during layout changes. Added new layout to portals library without the color.