### PR TITLE
Fix(ios): if manually syncing, apply previous live update instance data

### DIFF
--- a/ios/IonicPortals/IonicPortals/PortalBuilder.swift
+++ b/ios/IonicPortals/IonicPortals/PortalBuilder.swift
@@ -56,10 +56,12 @@ public class PortalBuilder: NSObject {
     public func setLiveUpdateConfig(liveUpdateConfig: LiveUpdate, updateOnAppLoad: Bool = true) -> PortalBuilder {
         self.liveUpdateConfig = liveUpdateConfig
         LiveUpdateManager.initialize()
-        LiveUpdateManager.cleanVersions(liveUpdateConfig.getAppId())
+        LiveUpdateManager.cleanVersions(liveUpdateConfig.appId)
         LiveUpdateManager.addLiveUpdateInstance(liveUpdateConfig)
         if (updateOnAppLoad) {
-            LiveUpdateManager.sync(appId: liveUpdateConfig.getAppId())
+            LiveUpdateManager.sync(appId: liveUpdateConfig.appId)
+        } else {
+            LiveUpdateManager.setupAppInstancesWithoutSync()
         }
         return self
     }

--- a/ios/IonicPortals/IonicPortals/PortalWebView.swift
+++ b/ios/IonicPortals/IonicPortals/PortalWebView.swift
@@ -27,7 +27,7 @@ public class PortalWebView: UIView {
             guard let portal = portal else { return }
 
             if let liveUpdateConfig = portal.liveUpdateConfig {
-                self.liveUpdatePath = LiveUpdateManager.getLatestAppDirectory(liveUpdateConfig.getAppId())
+                self.liveUpdatePath = LiveUpdateManager.getLatestAppDirectory(liveUpdateConfig.appId)
             }
             webView = InternalCapWebView(frame: self.frame, portal: portal, liveUpdatePath: self.liveUpdatePath)
             
@@ -49,7 +49,7 @@ public class PortalWebView: UIView {
         guard let bridge = bridge else { return }
         guard let liveUpdate = portal.liveUpdateConfig else { return }
         guard let capViewController = bridge.viewController as? CAPBridgeViewController else { return }
-        guard let latestAppPath = LiveUpdateManager.getLatestAppDirectory(liveUpdate.getAppId()) else { return }
+        guard let latestAppPath = LiveUpdateManager.getLatestAppDirectory(liveUpdate.appId) else { return }
 
         if (liveUpdatePath == nil || liveUpdatePath?.path != latestAppPath.path) {
             liveUpdatePath = latestAppPath


### PR DESCRIPTION
Depends on [this Live Updates PR](https://github.com/ionic-team/live-updates-sdk/pull/19)