### PR TITLE
docs: version split for ios and android in docs

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -17,5 +17,7 @@
     }
   },
   "version": "0.5.0",
+  "iosVersion": "0.5.1",
+  "androidVersion": "0.5.0",
   "capacitorVersion": "3.4.1"
 }

--- a/website/docs/getting-started/guide.md
+++ b/website/docs/getting-started/guide.md
@@ -6,7 +6,7 @@ sidebar_label: Getting Started Guide
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
-import { getCapacitorVersion, getPortalsVersion } from '@site/src/util';
+import { getCapacitorVersion, getPortalsVersion, getPortalsVersionIos, getPortalsVersionAndroid } from '@site/src/util';
 
 ## Signup
 
@@ -36,7 +36,7 @@ values={[
 To add Portals to your iOS project, put the following line to your `Podfile`:
 
 <CodeBlock className="language-ruby" title="Podfile">
-{`pod 'IonicPortals', '~> ${getPortalsVersion()}'`}
+{`pod 'IonicPortals', '~> ${getPortalsVersionIos()}'`}
 </CodeBlock>
 
 And then run `pod install`.
@@ -53,7 +53,7 @@ To add Portals to your Android project, add the dependency to your `build.gradle
 //  Module-level build.gradle
 // ----------------------------------------------
 dependencies {
-    implementation 'io.ionic:portals:${getPortalsVersion()}'
+    implementation 'io.ionic:portals:${getPortalsVersionAndroid()}'
 }`.trim()
 }
 </CodeBlock>

--- a/website/docs/getting-started/live-updates.md
+++ b/website/docs/getting-started/live-updates.md
@@ -6,7 +6,7 @@ sidebar_label: Live Updates
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
-import { getCapacitorVersion, getPortalsVersion } from '@site/src/util';
+import { getCapacitorVersion, getPortalsVersion, getPortalsVersionIos, getPortalsVersionAndroid } from '@site/src/util';
 
 Getting started with Live Updates in your Portals app.
 
@@ -43,7 +43,7 @@ values={[
 Live Updates is already added to your iOS project if you have the depdency for Portals in your `Podfile`:
 
 <CodeBlock className="language-ruby" title="Podfile">
-{`pod 'IonicPortals', '~> ${getPortalsVersion()}'`}
+{`pod 'IonicPortals', '~> ${getPortalsVersionIos()}'`}
 </CodeBlock>
 
 And then run `pod install`.
@@ -60,7 +60,7 @@ To add Live Updates to your Portals Android project, add the dependency to your 
 //  Module-level build.gradle
 // ----------------------------------------------
 dependencies {
-    implementation 'io.ionic:portals:${getPortalsVersion()}'
+    implementation 'io.ionic:portals:${getPortalsVersionAndroid()}'
     implementation 'io.ionic:liveupdates:0.0.5'
 }`.trim()
 }

--- a/website/docs/how-to/define-api-in-typescript.md
+++ b/website/docs/how-to/define-api-in-typescript.md
@@ -6,7 +6,7 @@ sidebar_label: Define your own Portal APIs
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
-import { getCapacitorVersion, getPortalsVersion } from '@site/src/util';
+import { getCapacitorVersion, getPortalsVersion, getPortalsVersionIos, getPortalsVersionAndroid } from '@site/src/util';
 
 One of the biggest benefits of including Ionic Portals in an application is the ability to easily communicate between web and native code using the [PortalsPlugin](../reference/web/portals-plugin). However, in some more niche cases, creating your own Plugins may be neccessary. By creating a [Capacitor Plugin](https://capacitorjs.com/docs/plugins/creating-plugins), you can create your own API to communicate between web and native code.
 

--- a/website/docs/how-to/using-a-capacitor-plugin.md
+++ b/website/docs/how-to/using-a-capacitor-plugin.md
@@ -6,7 +6,7 @@ sidebar_label: Use a Capacitor Plugin
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
-import { getPortalsVersion } from '@site/src/util';
+import { getPortalsVersion, getPortalsVersionIos, getPortalsVersionAndroid } from '@site/src/util';
 
 Ionic Portals uses Capacitor under the hood, meaning that you can use [Capacitor Core Plugins](https://capacitorjs.com/docs/apis) in your Portals. These plugins allow Portals to use native functionality with minimal configuration by the native developer or the web developer.
 
@@ -24,7 +24,7 @@ In order to use a Capacitor Plugin, you need to install the plugin as a dependen
 
 <CodeBlock className="language-ruby" title="Podfile">
 {
-`pod 'IonicPortals', '~> ${getPortalsVersion()}'
+`pod 'IonicPortals', '~> ${getPortalsVersionIos()}'
 pod 'CapacitorStorage', '~> 1.2.0'
 `.trim()
 }
@@ -144,7 +144,7 @@ In order to use a Capacitor Plugin, you need to install the plugin as a dependen
 {
 `
 dependencies {
-    implementation 'io.ionic:portals:${getPortalsVersion()}'
+    implementation 'io.ionic:portals:${getPortalsVersionAndroid()}'
     implementation 'com.capacitorjs.storage:1.2.0'
 }`.trim()
 }

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -64,6 +64,8 @@ module.exports = {
   ],
   customFields: {
     portalsVersion: lernaConfig.version,
+    portalsVersionIos: lernaConfig.iosVersion,
+    portalsVersionAndroid: lernaConfig.androidVersion,
     capacitorVersion: lernaConfig.capacitorVersion,
   }
 };

--- a/website/src/util/index.ts
+++ b/website/src/util/index.ts
@@ -10,3 +10,13 @@ export const getPortalsVersion = () => {
     const { siteConfig } = useDocusaurusContext();
     return siteConfig.customFields.portalsVersion;
 }
+
+export const getPortalsVersionIos = () => {
+    const { siteConfig } = useDocusaurusContext();
+    return siteConfig.customFields.portalsVersionIos;
+}
+
+export const getPortalsVersionAndroid = () => {
+    const { siteConfig } = useDocusaurusContext();
+    return siteConfig.customFields.portalsVersionAndroid;
+}


### PR DESCRIPTION
Creates two separate variables, one for each platform, to display latest version in the docs.

The process to update the docs would be to update the two values manually for now.