### PR TITLE
docs: capacitor plugin instructions for non-core plugins

### DIFF
--- a/website/docs/how-to/using-a-capacitor-plugin.md
+++ b/website/docs/how-to/using-a-capacitor-plugin.md
@@ -8,7 +8,11 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import { getPortalsVersion, getPortalsVersionIos, getPortalsVersionAndroid } from '@site/src/util';
 
-Ionic Portals uses Capacitor under the hood, meaning that you can use [Capacitor Core Plugins](https://capacitorjs.com/docs/apis) in your Portals. These plugins allow Portals to use native functionality with minimal configuration by the native developer or the web developer.
+Ionic Portals uses Capacitor under the hood, meaning that you can use [Capacitor Plugins](https://capacitorjs.com/docs/plugins) in your Portals. This means you can take advantage of our suite of [Capacitor Core Plugins](https://capacitorjs.com/docs/apis) in your Portals, as well as any plugins made by the community. These plugins allow Portals to use native functionality with minimal configuration by the native developer or the web developer.
+
+## Core Plugins
+
+Capacitor [Core Plugins](https://capacitorjs.com/docs/apis) are plugins built by the Capacitor team and provided for you to use conveniently through public repositories.
 
 <Tabs 
     defaultValue="ios" 
@@ -19,8 +23,8 @@ Ionic Portals uses Capacitor under the hood, meaning that you can use [Capacitor
 >
 <TabItem value="ios">
 
-## Native Usage
-In order to use a Capacitor Plugin, you need to install the plugin as a dependency in your `Podfile`.
+### iOS Native Usage
+In order to use a Capacitor Core Plugin, you need to install the plugin as a dependency in your `Podfile`.
 
 <CodeBlock className="language-ruby" title="Podfile">
 {
@@ -46,7 +50,7 @@ override func viewDidLoad() {
 }
 ```
 
-## Published Plugins
+### Published Plugins
 
 In CocoaPods, the Capacitor plugins are prepended with `Capacitor`. For example, the `@capacitor/storage` plugin on npm is named `CapacitorStorage` on CocoaPods. The following Plugins are available in CocoaPods.
 
@@ -137,8 +141,8 @@ The Toast API provides a notification pop up for displaying important informatio
 </TabItem>
 <TabItem value="android">
 
-## Native Usage
-In order to use a Capacitor Plugin, you need to install the plugin as a dependency in your `build.gradle` file.
+### Android Native Usage
+In order to use a Capacitor Core Plugin, you need to install the plugin as a dependency in your `build.gradle` file.
 
 <CodeBlock className="language-groovy" title="build.gradle">
 {
@@ -183,7 +187,7 @@ builder = builder.addPlugin(MyPlugin.class)
 
 </Tabs>
 
-## Published Plugins
+### Published Plugins
 
 In MavenCentral, the Capacitor plugins are prepended with `com.capacitorjs`. For example, the `@capacitor/storage` plugin on npm is named `com.capacitorjs.storage` on Maven. The following Plugins are available in MavenCentral.
 
@@ -275,7 +279,7 @@ The Toast API provides a notification pop up for displaying important informatio
 </TabItem>
 </Tabs>
 
-## Web Usage
+### Web Usage
 Web Developers need to install the web dependencies of the plugins from `npm`. The packages are listed under the `@capacitor` scope. To install a plugin, run `npm i @capacitor/<plugin_name>` from the root of your web project.
 
 :::warning
@@ -283,3 +287,121 @@ To avoid errors, make sure that the versions in your `Podfile`, `build.gradle`, 
 :::
 
 For more information on how to use Capacitor Plugins in your web application, [check out the Capacitor Plugin docs](https://capacitorjs.com/docs/apis).
+
+## Other Plugins
+
+Any plugin built for Capacitor can be linked in to a project using Portals even if it is not available through public native repositories like the core plugins are.
+
+### Download the Plugin
+
+Get the source code for the plugin and integrate it into your web app. If it is a Capacitor plugin, it is likely that it will be available through NPM.
+
+```shell
+npm i @capacitor-community/stripe
+```
+
+### Link the Plugin Natively
+
+The native code from the plugin needs to be made available to each native project using Portals.
+
+<Tabs 
+    defaultValue="ios" 
+    values={[
+        { label: 'iOS', value: 'ios', },
+        { label: 'Android', value: 'android', },
+    ]}
+>
+<TabItem value="ios">
+
+Fill me in
+
+</TabItem>
+<TabItem value="android">
+
+In your project `settings.gradle` file, define a path to the plugin android native project code.
+
+```groovy
+include ':capacitor-plugin-name'
+project(':capacitor-plugin-name').projectDir = new File('../../webapp/node_modules/@custom-capacitor/plugin/android')
+```
+
+Then in your project module level `build.gradle` file, add the project to the dependencies.
+
+```groovy
+dependencies {
+    implementation project(':capacitor-plugin-name')
+    implementation 'io.ionic:portals:0.5.0'
+
+    //...
+}
+```
+
+If successful, you should now see a section in the Android Studio project browser for your plugin, be able to browse its source code, and reference classes in the plugin within your native application source code.
+
+</TabItem>
+</Tabs>
+
+### Register the Plugin
+
+<Tabs 
+    defaultValue="ios" 
+    values={[
+        { label: 'iOS', value: 'ios', },
+        { label: 'Android', value: 'android', },
+    ]}
+>
+<TabItem value="ios">
+
+Fill me in
+
+</TabItem>
+<TabItem value="android">
+
+Register the plugin with a portal to use it.
+
+<Tabs 
+    defaultValue="kt" 
+    values={[
+        { label: 'Kotlin', value: 'kt', },
+        { label: 'Java', value: 'java', },
+    ]}
+>
+<TabItem value="kt">
+
+```kotlin
+class MyApplication : Application() {
+    override fun onCreate(): Unit {
+        super.onCreate()
+        PortalManager.register("MY_API_KEY")
+
+        val portalId = "MY_FIRST_PORTAL"
+        PortalManager.newPortal(portalId)
+                     .addPlugin(MyCapacitorPlugin::class.java)
+                     .create()
+    }
+}
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+public class MyApplication extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        PortalManager.register("MY_API_KEY");
+
+        String portalId = "MY_FIRST_PORTAL";
+        PortalManager.newPortal(portalId)
+                     .addPlugin(MyCapacitorPlugin.class)
+                     .create();
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+</Tabs>

--- a/website/docs/how-to/using-a-capacitor-plugin.md
+++ b/website/docs/how-to/using-a-capacitor-plugin.md
@@ -313,7 +313,11 @@ The native code from the plugin needs to be made available to each native projec
 >
 <TabItem value="ios">
 
-Fill me in
+In your project `Podfile`, define the path to the to the plugin's Podspec file.
+```ruby 
+pod CapacitorPluginName, :path => '../../webapp/node_modules/@custom-capacitor/plugin'
+```
+Make sure that the directory path is the root of where the CapacitorPluginName.podspec file is. This is typically the source root of the plugin project, not in the platform specific subfolder.
 
 </TabItem>
 <TabItem value="android">
@@ -352,7 +356,7 @@ If successful, you should now see a section in the Android Studio project browse
 >
 <TabItem value="ios">
 
-Fill me in
+Plugins are automatically registered on iOS.
 
 </TabItem>
 <TabItem value="android">

--- a/website/docs/how-to/using-a-capacitor-plugin.md
+++ b/website/docs/how-to/using-a-capacitor-plugin.md
@@ -313,11 +313,11 @@ The native code from the plugin needs to be made available to each native projec
 >
 <TabItem value="ios">
 
-In your project `Podfile`, define the path to the to the plugin's Podspec file.
+In your project `Podfile`, define the path to the folder containing the plugin's Podspec file.
 ```ruby 
 pod CapacitorPluginName, :path => '../../webapp/node_modules/@custom-capacitor/plugin'
 ```
-Make sure that the directory path is the root of where the CapacitorPluginName.podspec file is. This is typically the source root of the plugin project, not in the platform specific subfolder.
+The path to the Podspec file is typically the source root of the plugin project, not in the platform specific subfolder.
 
 </TabItem>
 <TabItem value="android">

--- a/website/docs/how-to/using-a-capacitor-plugin.md
+++ b/website/docs/how-to/using-a-capacitor-plugin.md
@@ -315,7 +315,7 @@ The native code from the plugin needs to be made available to each native projec
 
 In your project `Podfile`, define the path to the folder containing the plugin's Podspec file.
 ```ruby 
-pod CapacitorPluginName, :path => '../../webapp/node_modules/@custom-capacitor/plugin'
+pod 'CapacitorPluginName', :path => '../../webapp/node_modules/@custom-capacitor/plugin'
 ```
 The path to the Podspec file is typically the source root of the plugin project, not in the platform specific subfolder.
 


### PR DESCRIPTION
Adds instructions to the "Using a Capacitor Plugin" page to explain how to use any Capacitor plugin in Portals.