### PR TITLE
breaking(plugin): Make `publish` generic over Message and not Message data

### DIFF
--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@ionic/portals",
-      "version": "0.1.2",
+      "version": "0.5.0",
       "license": "Commercial",
       "devDependencies": {
         "@capacitor/android": "^3.0.0",

--- a/plugin/src/definitions.ts
+++ b/plugin/src/definitions.ts
@@ -3,7 +3,7 @@
  */
 export interface PortalsPlugin {
   getInitialContext<T = unknown>(): Promise<InitialContext<T>>;
-  publish<TData>(message: PortalMessage<TData>): Promise<void>;
+  publish<TMessage extends PortalMessage>(message: TMessage): Promise<void>;
   subscribe<T = unknown>(options: SubscribeOptions, callback: SubscriptionCallback<T>): Promise<PortalSubscription>;
   unsubscribe(options: PortalSubscription): Promise<void>;
 }


### PR DESCRIPTION
This should allow for doing things like this:
```typescript
type Messages = 
  | { topic: "cart:dismiss", data: "clear" | "cancel" }
  | { topic: "user:delete", data: User }

publish<Messages>({ topic: "cart:dismiss", data: "cancel" }) //totally fine
publish({ topic: "something:else", data: 1 }) // totally fine
publish<Messages>({ topic: "user:delete", data: "clear" }) // typescript error
publish<Messages>({ topic: "something:else", data: 1 }) // typescript error
```

Props to @eric-horodyski for the idea