### PR TITLE
feat: Update InitialContext

### DIFF
--- a/plugin/src/definitions.ts
+++ b/plugin/src/definitions.ts
@@ -12,7 +12,7 @@ export interface PortalsPlugin {
  */
 export interface InitialContext<T = unknown> {
   name: string;
-  value: T;
+  value: T | undefined;
 }
 
 /**

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -8,8 +8,13 @@ const Portals = registerPlugin<PortalsPlugin>('Portals', {
   ios: () => import('./ios').then(m => new m.PortalsIOS())
 });
 
+/**
+ * Provides access to any initial state provided by the native application.
+ * If the web application is running in a Portal, this will always be defined
+ * with the name property.
+ * */
 export function getInitialContext<T = unknown>(): InitialContext<T> | undefined {
-  return (window as any).portalInitialContext as { name: string, value: T; };
+  return (window as any).portalInitialContext;
 }
 
 export * from './definitions';

--- a/plugin/src/web.ts
+++ b/plugin/src/web.ts
@@ -15,7 +15,7 @@ export class PortalsWeb extends WebPlugin implements PortalsPlugin {
     return {
       subscriptionRef: -0,
       topic: ""
-    }
+    };
   }
 
   async unsubscribe(_options: PortalSubscription): Promise<void> {}

--- a/plugin/src/web.ts
+++ b/plugin/src/web.ts
@@ -9,10 +9,14 @@ import {
 } from './definitions';
 
 export class PortalsWeb extends WebPlugin implements PortalsPlugin {
-  async publish(_message: PortalMessage): Promise<void> { }
-  async subscribe<T = unknown>(_options: SubscribeOptions, _callback: SubscriptionCallback<T>): Promise<PortalSubscription> { return null as any; }
-  async unsubscribe(_options: PortalSubscription): Promise<void> { }
-  async echo(options: { value: string; }): Promise<{ value: string; }> {
-    return options;
+  async publish(_message: PortalMessage): Promise<void> {}
+
+  async subscribe<T = unknown>(_options: SubscribeOptions, _callback: SubscriptionCallback<T>): Promise<PortalSubscription> {
+    return {
+      subscriptionRef: -0,
+      topic: ""
+    }
   }
+
+  async unsubscribe(_options: PortalSubscription): Promise<void> {}
 }


### PR DESCRIPTION
feat: Make InitialContext.value T | undefined. This is to support that InitialContext will always be available when run in a portal context with at least the name value defined. This now makes `getInitialContext` an indicator to the web developers whether or not their code is being executed inside of a Portal or not without the native team having to provide any initialContext if it is not needed.

BREAKING CHANGE
This is an API breaking change since InitialContext<T> was initially assumed to always have a value provided if it was present. This is now changed so that we always provide access to the name of the portal to the web code to avoid there being strong coupling to the name.