### PR TITLE
fix(website): bump docusaurus theme dep [HOLD]

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,7 +11,7 @@
         "@docusaurus/core": "2.0.0-beta.8",
         "@docusaurus/preset-classic": "2.0.0-beta.8",
         "@ionic-internal/docusaurus-plugin-tag-manager": "2.0.0",
-        "@ionic-internal/docusaurus-theme": "^3.0.6",
+        "@ionic-internal/docusaurus-theme": "^3.0.7",
         "@ionic-internal/ionic-ds": "^7.1.0",
         "@ionic/prettier-config": "^2.0.0",
         "@svgr/webpack": "^5.5.0",
@@ -2480,9 +2480,9 @@
       }
     },
     "node_modules/@ionic-internal/docusaurus-theme": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@ionic-internal/docusaurus-theme/-/docusaurus-theme-3.0.6.tgz",
-      "integrity": "sha512-21GZUUGUCY2OQvWN/QdF+XkPdacIxF9JPwlHQb4qkwwTipJ7jkqmJQQMwSxGs076NoeTMDZc4x4Swz9DBpvgqw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@ionic-internal/docusaurus-theme/-/docusaurus-theme-3.0.7.tgz",
+      "integrity": "sha512-IRtzq+KxZNoVHHcoPBC9fB1JUugdKgLmCdpSLSr1eECdeFrjv7+aOu2OK40Q5IG81eigW622yXLZiPp2V5R1uA==",
       "peerDependencies": {
         "@docusaurus/core": ">=2.0.0-beta.0",
         "@ionic-internal/ionic-ds": ">=7.0.0",
@@ -17376,9 +17376,9 @@
       "requires": {}
     },
     "@ionic-internal/docusaurus-theme": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@ionic-internal/docusaurus-theme/-/docusaurus-theme-3.0.6.tgz",
-      "integrity": "sha512-21GZUUGUCY2OQvWN/QdF+XkPdacIxF9JPwlHQb4qkwwTipJ7jkqmJQQMwSxGs076NoeTMDZc4x4Swz9DBpvgqw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@ionic-internal/docusaurus-theme/-/docusaurus-theme-3.0.7.tgz",
+      "integrity": "sha512-IRtzq+KxZNoVHHcoPBC9fB1JUugdKgLmCdpSLSr1eECdeFrjv7+aOu2OK40Q5IG81eigW622yXLZiPp2V5R1uA==",
       "requires": {}
     },
     "@ionic-internal/ionic-ds": {

--- a/website/package.json
+++ b/website/package.json
@@ -17,7 +17,7 @@
     "@docusaurus/core": "2.0.0-beta.8",
     "@docusaurus/preset-classic": "2.0.0-beta.8",
     "@ionic-internal/docusaurus-plugin-tag-manager": "2.0.0",
-    "@ionic-internal/docusaurus-theme": "^3.0.6",
+    "@ionic-internal/docusaurus-theme": "^3.0.7",
     "@ionic-internal/ionic-ds": "^7.1.0",
     "@ionic/prettier-config": "^2.0.0",
     "@svgr/webpack": "^5.5.0",


### PR DESCRIPTION
This will fix the back button. It will now point to [the ionic docs landing page](https://ionic.io/docs)
<img width="347" alt="Screenshot 2023-05-04 at 10 39 57 AM" src="https://user-images.githubusercontent.com/61951482/236269621-00dd256f-812f-44d1-9c21-3d8f01c80d6e.png">
