### PR TITLE
docs(android): version compatibility page

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,9 +1,9 @@
 {
   "version": "0.8.1",
   "iosVersion": "0.8.0",
-  "androidVersion": "0.8.2",
+  "androidVersion": "0.8.3",
   "rnVersion": "0.5.0",
-  "capacitorVersion": "5.0.0",
+  "capacitorVersion": "5.5.0",
   "iosMinVersion": "13.0",
   "androidMinSdk": "22",
   "rnMinVersion": "0.63.4",

--- a/website/docs/for-android/guide.md
+++ b/website/docs/for-android/guide.md
@@ -62,6 +62,8 @@ To add Portals to your web project, install it via NPM:
 {`npm install @ionic/portals@${getPortalsVersion()}`}
 </CodeBlock>
 
+If you need help configuring specific versions of Portals with Capacitor or Capacitor Plugins, check out our [SDK Version Compatibility](./version-matrix) page.
+
 ## Configure
 
 After installing the dependency you need to register your copy of Ionic Portals at runtime. This works both offline and in production. You'll need to call [PortalManager.register(myApiKey)](https://ionic.io/docs/portals-android-api-ref/-ionic-portals/io.ionic.portals/-portal-manager/index.html#-1847662668%2FFunctions%2F-149544105) before creating any Portals in your app. Below is a simple example of how to bootstrap Ionic Portals before loading any Portal instances in your app. To get an API Key, refer to the [Sign Up](#signup) section.

--- a/website/docs/for-android/upgrade-guides.md
+++ b/website/docs/for-android/upgrade-guides.md
@@ -7,6 +7,8 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 
+If you need help configuring specific versions of Portals with Capacitor or Capacitor Plugins, check out our [SDK Version Compatibility](./version-matrix) page.
+
 ## IonicPortals Android 0.7.x -> 0.8.0
 
 IonicPortals Android version 0.8.0 is compatible with '@ionic/portals' version 0.8.x

--- a/website/docs/for-android/version-matrix.md
+++ b/website/docs/for-android/version-matrix.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import { getCapacitorVersion, getPortalsVersion, getPortalsVersionIos, getPortalsVersionAndroid, getPortalsVersionRN, getiOSMinVersion, getAndroidMinSdk, getRnMinVersion } from '@site/src/util';
 
-This guide is designed to help you align versions of the Native Android Portals SDK with the Portals Web Plugin and Capacitor.
+This guide is designed to help you align versions of the Native Android Portals SDK with the Portals Web Plugin and Capacitor. [Click here](./version-matrix#sdk_version_compatibility_matrix) to jump straight to the version compatibility matrix.
 
 ## Matching Dependency Versions
 
@@ -62,7 +62,7 @@ For more information refer to the Gradle documentation pages:
 - https://docs.gradle.org/current/userguide/dependency_downgrade_and_exclude.html
 - https://docs.gradle.org/current/userguide/dependency_constraints.html
 
-# SDK Version Compatibility Matrix
+## SDK Version Compatibility Matrix
 
 | Android SDK | Web Plugin Version | Compiled Capacitor Version | Compatible Capacitor Versions |
 | :----:      | :----:             | :----:                     | :----:                        |

--- a/website/docs/for-android/version-matrix.md
+++ b/website/docs/for-android/version-matrix.md
@@ -1,0 +1,59 @@
+---
+title: Android SDK Version Compatibility Guide
+sidebar_label: SDK Version Compatibility
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
+import { getCapacitorVersion, getPortalsVersion, getPortalsVersionIos, getPortalsVersionAndroid, getPortalsVersionRN, getiOSMinVersion, getAndroidMinSdk, getRnMinVersion } from '@site/src/util';
+
+This guide is designed to help you align versions of the Native Android Portals SDK with the Portals Web Plugin and Capacitor.
+
+## Matching Dependency Versions
+
+Ideally, the version of Capacitor used by the Web App from NPM should match the version of Capacitor used by Portals in the native SDK. The `Compatible Capacitor Versions` column shows versions of Capacitor that are generally compatible with that version of Portals and should not cause any issues. If you are trying to target a specific version of Capacitor that contains a fix or feature you need, make sure you use the appropriate version of Portals and the Portals Plugin that is compatible.
+
+For example, referencing the matrix below, if you are using Portals versions 0.7.1 to 0.7.3, the web plugin version should be 0.7.0 and ideally you would be using Capacitor version 4.6.1. However, Capacitor versions 4.6.3 to 4.7.0 would work. 
+
+## SDK Version Compatibility Matrix
+
+| Android SDK | Web Plugin Version | Compiled Capacitor Version | Compatible Capacitor Versions |
+| :----:      | :----:             | :----:                     | :----:                        |
+| 0.8.3       | 0.8.1              | 5.5.+                      | 5.0.3 - 5.5.0                 | 
+| 0.8.2       | 0.8.1              | 5.4.2                      | 5.0.3 - 5.5.0                 | 
+| 0.8.1       | 0.8.1              | 5.4.2                      | 5.0.3 - 5.5.0                 | 
+| 0.8.0       | 0.8.1              | 5.0.3                      | 5.0.3 - 5.5.0                 | 
+| 0.7.5       | 0.7.1              | 4.7.3                      | 4.7.0 - 4.8.0                 | 
+| 0.7.4       | 0.7.1              | 4.7.0                      | 4.7.0 - 4.8.0                 | 
+| 0.7.3       | 0.7.0              | 4.6.1                      | 4.4.0 - 4.6.3                 | 
+| 0.7.2       | 0.7.0              | 4.6.1                      | 4.4.0 - 4.6.3                 | 
+| 0.7.1       | 0.7.0              | 4.6.1                      | 4.4.0 - 4.6.3                 | 
+| 0.7.0       | 0.7.0              | 4.5.0                      | 4.4.0 - 4.6.3                 | 
+| 0.6.4       | 0.6.0              | 3.9.0                      | 3.5.1 - 3.9.0                 | 
+| 0.6.3       | 0.6.0              | 3.7.0                      | 3.5.1 - 3.9.0                 | 
+| 0.6.2       | 0.6.0              | 3.5.1                      | 3.5.1 - 3.9.0                 | 
+| 0.6.1       | 0.6.0              | 3.5.1                      | 3.5.1 - 3.9.0                 | 
+| 0.6.0       | 0.6.0              | 3.5.1                      | 3.5.1 - 3.9.0                 | 
+| 0.5.1       | 0.5.0              | 3.5.1                      | 3.5.1 - 3.9.0                 | 
+| 0.5.0       | 0.5.0              | 3.4.1                      | 3.3.0 - 3.5.0                 | 
+| 0.4.1       | 0.4.1              | 3.4.0                      | 3.3.0 - 3.5.0                 | 
+| 0.3.1       | 0.3.1              | 3.3.3                      | 3.3.0 - 3.5.0                 | 
+| 0.3.0       | 0.3.0              | 3.3.2                      | 3.3.0 - 3.5.0                 | 
+| 0.2.2       | 0.2.2              | 3.2.5                      | 3.2.2 - 3.2.5                 | 
+| 0.2.1       | 0.2.1              | 3.2.4                      | 3.2.2 - 3.2.5                 | 
+| 0.2.0       | 0.2.0              | 3.2.2                      | 3.2.2 - 3.2.5                 | 
+
+## How Gradle Resolves Dependency Versions
+
+By default, Gradle will use the version of Capacitor that the Portals SDK depends on. If the app includes multiple dependencies that depend on different versions of Capacitor, Gradle will try to resolve the conflict by using the highest version in the dependency tree. 
+
+Reference: https://docs.gradle.org/current/userguide/dependency_resolution.html
+
+## Overriding Compiled Capacitor Versions in Gradle
+
+Gradle allows you to override and use a specific version of Capacitor that Portals or a Capacitor Plugin dependency will use.
+
+:::warning
+Use the version compatibility matrix above when choosing a version of Capacitor to override to ensure the version will be compatible. If balancing a version between Portals and a Capacitor Plugin, reference the documentation or change log for the Plugin to make sure the Capacitor version chosen will be compatible.
+:::

--- a/website/docs/for-android/version-matrix.md
+++ b/website/docs/for-android/version-matrix.md
@@ -78,7 +78,7 @@ dependencies {
     exclude group: 'com.capacitorjs', module: 'core'
   }
 
-  implementation('com.capacitorjs:camera:') {
+  implementation('com.capacitorjs:camera:5.0.7') {
     exclude group: 'com.capacitorjs', module: 'core'
   }
 

--- a/website/docs/for-android/version-matrix.md
+++ b/website/docs/for-android/version-matrix.md
@@ -86,4 +86,6 @@ dependencies {
 }
 ```
 
-More information: https://docs.gradle.org/current/userguide/dependency_constraints.html
+For more information refer to the Gradle documentation pages:
+- https://docs.gradle.org/current/userguide/dependency_downgrade_and_exclude.html
+- https://docs.gradle.org/current/userguide/dependency_constraints.html

--- a/website/docs/for-android/version-matrix.md
+++ b/website/docs/for-android/version-matrix.md
@@ -50,10 +50,40 @@ By default, Gradle will use the version of Capacitor that the Portals SDK depend
 
 Reference: https://docs.gradle.org/current/userguide/dependency_resolution.html
 
-## Overriding Compiled Capacitor Versions in Gradle
+## Determining Capacitor Versions in Gradle
 
-Gradle allows you to override and use a specific version of Capacitor that Portals or a Capacitor Plugin dependency will use.
+Gradle allows you to use a specific version of Capacitor that Portals or a Capacitor Plugin dependency will use.
 
 :::warning
-Use the version compatibility matrix above when choosing a version of Capacitor to override to ensure the version will be compatible. If balancing a version between Portals and a Capacitor Plugin, reference the documentation or change log for the Plugin to make sure the Capacitor version chosen will be compatible.
+Use the version compatibility matrix above when choosing a version of Capacitor to ensure it will be compatible. When balancing a version between Portals and a Capacitor plugin, reference the documentation or change log for the plugin to make sure the Capacitor version will be compatible.
 :::
+
+The following example will use the version of the Capacitor dependency included via the Capacitor Camera plugin.
+
+```groovy
+dependencies {
+  implementation('io.ionic:portals:0.8.0') {
+    exclude group: 'com.capacitorjs', module: 'core'
+  }
+
+  implementation 'com.capacitorjs:camera:5.0.7'
+}
+```
+
+The following example will use the version of the Capacitor dependency specifified in the dependencies block. Neither of the Capacitor versions included with Portals or the Capacitor Camera plugin will be used.
+
+```groovy
+dependencies {
+  implementation('io.ionic:portals:0.8.0') {
+    exclude group: 'com.capacitorjs', module: 'core'
+  }
+
+  implementation('com.capacitorjs:camera:') {
+    exclude group: 'com.capacitorjs', module: 'core'
+  }
+
+  implementation 'com.capacitorjs:core:5.5.0'
+}
+```
+
+More information: https://docs.gradle.org/current/userguide/dependency_constraints.html

--- a/website/docs/for-android/version-matrix.md
+++ b/website/docs/for-android/version-matrix.md
@@ -14,35 +14,7 @@ This guide is designed to help you align versions of the Native Android Portals 
 
 Ideally, the version of Capacitor used by the Web App from NPM should match the version of Capacitor used by Portals in the native SDK. The `Compatible Capacitor Versions` column shows versions of Capacitor that are generally compatible with that version of Portals and should not cause any issues. If you are trying to target a specific version of Capacitor that contains a fix or feature you need, make sure you use the appropriate version of Portals and the Portals Plugin that is compatible.
 
-For example, referencing the matrix below, if you are using Portals versions 0.7.1 to 0.7.3, the web plugin version should be 0.7.0 and ideally you would be using Capacitor version 4.6.1. However, Capacitor versions 4.6.3 to 4.7.0 would work. 
-
-## SDK Version Compatibility Matrix
-
-| Android SDK | Web Plugin Version | Compiled Capacitor Version | Compatible Capacitor Versions |
-| :----:      | :----:             | :----:                     | :----:                        |
-| 0.8.3       | 0.8.1              | 5.5.+                      | 5.0.3 - 5.5.0                 | 
-| 0.8.2       | 0.8.1              | 5.4.2                      | 5.0.3 - 5.5.0                 | 
-| 0.8.1       | 0.8.1              | 5.4.2                      | 5.0.3 - 5.5.0                 | 
-| 0.8.0       | 0.8.1              | 5.0.3                      | 5.0.3 - 5.5.0                 | 
-| 0.7.5       | 0.7.1              | 4.7.3                      | 4.7.0 - 4.8.0                 | 
-| 0.7.4       | 0.7.1              | 4.7.0                      | 4.7.0 - 4.8.0                 | 
-| 0.7.3       | 0.7.0              | 4.6.1                      | 4.4.0 - 4.6.3                 | 
-| 0.7.2       | 0.7.0              | 4.6.1                      | 4.4.0 - 4.6.3                 | 
-| 0.7.1       | 0.7.0              | 4.6.1                      | 4.4.0 - 4.6.3                 | 
-| 0.7.0       | 0.7.0              | 4.5.0                      | 4.4.0 - 4.6.3                 | 
-| 0.6.4       | 0.6.0              | 3.9.0                      | 3.5.1 - 3.9.0                 | 
-| 0.6.3       | 0.6.0              | 3.7.0                      | 3.5.1 - 3.9.0                 | 
-| 0.6.2       | 0.6.0              | 3.5.1                      | 3.5.1 - 3.9.0                 | 
-| 0.6.1       | 0.6.0              | 3.5.1                      | 3.5.1 - 3.9.0                 | 
-| 0.6.0       | 0.6.0              | 3.5.1                      | 3.5.1 - 3.9.0                 | 
-| 0.5.1       | 0.5.0              | 3.5.1                      | 3.5.1 - 3.9.0                 | 
-| 0.5.0       | 0.5.0              | 3.4.1                      | 3.3.0 - 3.5.0                 | 
-| 0.4.1       | 0.4.1              | 3.4.0                      | 3.3.0 - 3.5.0                 | 
-| 0.3.1       | 0.3.1              | 3.3.3                      | 3.3.0 - 3.5.0                 | 
-| 0.3.0       | 0.3.0              | 3.3.2                      | 3.3.0 - 3.5.0                 | 
-| 0.2.2       | 0.2.2              | 3.2.5                      | 3.2.2 - 3.2.5                 | 
-| 0.2.1       | 0.2.1              | 3.2.4                      | 3.2.2 - 3.2.5                 | 
-| 0.2.0       | 0.2.0              | 3.2.2                      | 3.2.2 - 3.2.5                 | 
+For example: referencing the matrix at the bottom of the page, if you are using Portals versions 0.7.1 to 0.7.3, the web plugin version should be 0.7.0 and ideally you would be using Capacitor version 4.6.1. However, Capacitor versions 4.6.3 to 4.7.0 would work.
 
 ## How Gradle Resolves Dependency Versions
 
@@ -55,7 +27,7 @@ Reference: https://docs.gradle.org/current/userguide/dependency_resolution.html
 Gradle allows you to use a specific version of Capacitor that Portals or a Capacitor Plugin dependency will use.
 
 :::warning
-Use the version compatibility matrix above when choosing a version of Capacitor to ensure it will be compatible. When balancing a version between Portals and a Capacitor plugin, reference the documentation or change log for the plugin to make sure the Capacitor version will be compatible.
+Use the version compatibility matrix at the bottom of the page when choosing a version of Capacitor to ensure it will be compatible. When balancing a version between Portals and a Capacitor plugin, reference the documentation or change log for the plugin to make sure the Capacitor version will be compatible.
 :::
 
 The following example will use the version of the Capacitor dependency included via the Capacitor Camera plugin.
@@ -89,3 +61,31 @@ dependencies {
 For more information refer to the Gradle documentation pages:
 - https://docs.gradle.org/current/userguide/dependency_downgrade_and_exclude.html
 - https://docs.gradle.org/current/userguide/dependency_constraints.html
+
+# SDK Version Compatibility Matrix
+
+| Android SDK | Web Plugin Version | Compiled Capacitor Version | Compatible Capacitor Versions |
+| :----:      | :----:             | :----:                     | :----:                        |
+| 0.8.3       | 0.8.1              | 5.5.+                      | 5.0.3 - 5.5.0                 |
+| 0.8.2       | 0.8.1              | 5.4.2                      | 5.0.3 - 5.5.0                 |
+| 0.8.1       | 0.8.1              | 5.4.2                      | 5.0.3 - 5.5.0                 |
+| 0.8.0       | 0.8.1              | 5.0.3                      | 5.0.3 - 5.5.0                 |
+| 0.7.5       | 0.7.1              | 4.7.3                      | 4.7.0 - 4.8.0                 |
+| 0.7.4       | 0.7.1              | 4.7.0                      | 4.7.0 - 4.8.0                 |
+| 0.7.3       | 0.7.0              | 4.6.1                      | 4.4.0 - 4.6.3                 |
+| 0.7.2       | 0.7.0              | 4.6.1                      | 4.4.0 - 4.6.3                 |
+| 0.7.1       | 0.7.0              | 4.6.1                      | 4.4.0 - 4.6.3                 |
+| 0.7.0       | 0.7.0              | 4.5.0                      | 4.4.0 - 4.6.3                 |
+| 0.6.4       | 0.6.0              | 3.9.0                      | 3.5.1 - 3.9.0                 |
+| 0.6.3       | 0.6.0              | 3.7.0                      | 3.5.1 - 3.9.0                 |
+| 0.6.2       | 0.6.0              | 3.5.1                      | 3.5.1 - 3.9.0                 |
+| 0.6.1       | 0.6.0              | 3.5.1                      | 3.5.1 - 3.9.0                 |
+| 0.6.0       | 0.6.0              | 3.5.1                      | 3.5.1 - 3.9.0                 |
+| 0.5.1       | 0.5.0              | 3.5.1                      | 3.5.1 - 3.9.0                 |
+| 0.5.0       | 0.5.0              | 3.4.1                      | 3.3.0 - 3.5.0                 |
+| 0.4.1       | 0.4.1              | 3.4.0                      | 3.3.0 - 3.5.0                 |
+| 0.3.1       | 0.3.1              | 3.3.3                      | 3.3.0 - 3.5.0                 |
+| 0.3.0       | 0.3.0              | 3.3.2                      | 3.3.0 - 3.5.0                 |
+| 0.2.2       | 0.2.2              | 3.2.5                      | 3.2.2 - 3.2.5                 |
+| 0.2.1       | 0.2.1              | 3.2.4                      | 3.2.2 - 3.2.5                 |
+| 0.2.0       | 0.2.0              | 3.2.2                      | 3.2.2 - 3.2.5                 |

--- a/website/docs/for-android/version-matrix.md
+++ b/website/docs/for-android/version-matrix.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import { getCapacitorVersion, getPortalsVersion, getPortalsVersionIos, getPortalsVersionAndroid, getPortalsVersionRN, getiOSMinVersion, getAndroidMinSdk, getRnMinVersion } from '@site/src/util';
 
-This guide is designed to help you align versions of the Native Android Portals SDK with the Portals Web Plugin and Capacitor. [Click here](./version-matrix#sdk_version_compatibility_matrix) to jump straight to the version compatibility matrix.
+This guide is designed to help you align versions of the Native Android Portals SDK with the Portals Web Plugin and Capacitor. [Click here](./version-matrix#sdk-version-compatibility-matrix) to jump straight to the version compatibility matrix.
 
 ## Matching Dependency Versions
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -64,6 +64,7 @@ module.exports = {
           label: "Reference",
           collapsed: true,
           items: [
+            "version-matrix",
             {
               type: "link",
               label: "API",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -64,7 +64,6 @@ module.exports = {
           label: "Reference",
           collapsed: true,
           items: [
-            "version-matrix",
             {
               type: "link",
               label: "API",
@@ -131,6 +130,7 @@ module.exports = {
           label: "Reference",
           collapsed: true,
           items: [
+            "for-android/version-matrix",
             {
               type: "link",
               label: "API",


### PR DESCRIPTION
This adds a page to the Android reference section to check compatible versions of Portals SDK, Portals Plugin, and Capacitor.