### PR TITLE
feat!(plugin): Remove `SubscriptionCallback` type

### DIFF
--- a/plugin/src/definitions.ts
+++ b/plugin/src/definitions.ts
@@ -9,7 +9,7 @@ export interface PortalsPlugin {
   ): Promise<void>;
   addListener<T = unknown>(
     eventName: string,
-    listenerFunc: SubscriptionCallback<T>,
+    listenerFunc: (result: PortalMessage<T>) => void,
   ): Promise<PluginListenerHandle> & PluginListenerHandle;
 }
 
@@ -31,11 +31,3 @@ export interface PortalMessage<TData = any> {
   topic: string;
   data?: TData;
 }
-
-/**
- * The type definition from the callback running Portals.subscribe()
- */
-export type SubscriptionCallback<T = unknown> = (result: {
-  topic: string;
-  data: T;
-}) => void;

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -5,7 +5,6 @@ import type {
   InitialContext,
   PortalMessage,
   PortalsPlugin,
-  SubscriptionCallback,
 } from './definitions';
 
 const Portals = registerPlugin<PortalsPlugin>('Portals', {
@@ -20,9 +19,10 @@ const Portals = registerPlugin<PortalsPlugin>('Portals', {
 export function getInitialContext<T = unknown>():
   | InitialContext<T>
   | undefined {
-  if (Capacitor.getPlatform() === "android") {
+  if (Capacitor.getPlatform() === 'android') {
+    // eslint-disable-next-line
     //@ts-ignore
-    return JSON.parse(AndroidInitialContext.initialContext())
+    return JSON.parse(AndroidInitialContext.initialContext());
   } else {
     return (window as any).portalInitialContext;
   }
@@ -30,7 +30,7 @@ export function getInitialContext<T = unknown>():
 
 export function subscribe<T = unknown>(
   topic: string,
-  callback: SubscriptionCallback<T>,
+  callback: (result: PortalMessage<T>) => void,
 ): Promise<PluginListenerHandle> {
   return Portals.addListener(topic, callback);
 }

--- a/plugin/src/web.ts
+++ b/plugin/src/web.ts
@@ -4,5 +4,5 @@ import type { PortalMessage, PortalsPlugin } from './definitions';
 
 export class PortalsWeb extends WebPlugin implements PortalsPlugin {
   // eslint-disable-next-line
-  async publishNative(_message: PortalMessage): Promise<void> { }
+  async publishNative(_message: PortalMessage): Promise<void> {}
 }


### PR DESCRIPTION
This was out of sync with `PortalMessage`. The `data` property is not required, but the `SubscriptionCallback` marked it as required. I'm personally surprised this hasn't caused issues.